### PR TITLE
Updated the thermometer icon string for the Tuya extension to a constant

### DIFF
--- a/homeassistant/components/tuya/number.py
+++ b/homeassistant/components/tuya/number.py
@@ -18,6 +18,8 @@ from . import HomeAssistantTuyaData
 from .base import IntegerTypeData, TuyaEntity
 from .const import DEVICE_CLASS_UNITS, DOMAIN, TUYA_DISCOVERY_NEW, DPCode, DPType
 
+thermometer_icon = "mdi:thermometer"
+
 # All descriptions can be found here. Mostly the Integer data types in the
 # default instructions set of each category end up being a number.
 # https://developer.tuya.com/en/docs/iot/standarddescription?id=K9i5ql6waswzq
@@ -38,28 +40,28 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
             key=DPCode.TEMP_SET,
             translation_key="temperature",
             device_class=NumberDeviceClass.TEMPERATURE,
-            icon="mdi:thermometer",
+            icon=thermometer_icon,
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.TEMP_SET_F,
             translation_key="temperature",
             device_class=NumberDeviceClass.TEMPERATURE,
-            icon="mdi:thermometer",
+            icon=thermometer_icon,
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.TEMP_BOILING_C,
             translation_key="temperature_after_boiling",
             device_class=NumberDeviceClass.TEMPERATURE,
-            icon="mdi:thermometer",
+            icon=thermometer_icon,
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.TEMP_BOILING_F,
             translation_key="temperature_after_boiling",
             device_class=NumberDeviceClass.TEMPERATURE,
-            icon="mdi:thermometer",
+            icon=thermometer_icon,
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
@@ -117,7 +119,7 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
             key=DPCode.TEMP_SET,
             translation_key="temperature",
             device_class=NumberDeviceClass.TEMPERATURE,
-            icon="mdi:thermometer",
+            icon=thermometer_icon,
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
@@ -138,7 +140,7 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
         NumberEntityDescription(
             key=DPCode.COOK_TEMPERATURE,
             translation_key="cook_temperature",
-            icon="mdi:thermometer",
+            icon=thermometer_icon,
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(


### PR DESCRIPTION
2: It can be an issue if the icon string is a variable due to it being cumbersome to update in case the icon is to be changed in the future. 
3: By changing the string to a constant, the icon can be changed by simply changing the one added line at row 21 instead of having to update every instance of the string. 